### PR TITLE
[SECURITY] Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/GL/CraftBukkit/Current/pom.xml
+++ b/GL/CraftBukkit/Current/pom.xml
@@ -28,26 +28,26 @@
     <repository>
       <id>repobo-rel</id>
       <name>repo.bukkit.org Releases</name>
-      <url>http://repo.bukkit.org/content/repositories/releases/</url>
+      <url>https://repo.bukkit.org/content/repositories/releases/</url>
     </repository>
     <snapshotRepository>
       <id>repobo-snap</id>
       <name>repo.bukkit.org Snapshots</name>
-      <url>http://repo.bukkit.org/content/repositories/snapshots/</url>
+      <url>https://repo.bukkit.org/content/repositories/snapshots/</url>
     </snapshotRepository>
   </distributionManagement>
 
   <repositories>
     <repository>
       <id>repobo-snap</id>
-      <url>http://repo.bukkit.org/content/groups/public</url>
+      <url>https://repo.bukkit.org/content/groups/public</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
       <id>bukkit-plugins</id>
-      <url>http://repo.bukkit.org/content/groups/public</url>
+      <url>https://repo.bukkit.org/content/groups/public</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/GL/Essentials/Current/pom.xml
+++ b/GL/Essentials/Current/pom.xml
@@ -42,18 +42,18 @@
 	<repositories>
 		<repository>
 			<id>ess-repo</id>
-			<url>http://repo.ess3.net/content/groups/public</url>
+			<url>https://repo.ess3.net/content/groups/public</url>
 		</repository>
 	</repositories>
 
 	<distributionManagement>
 		<snapshotRepository>
 			<id>essdev</id>
-			<url>http://repo.ess3.net/content/repositories/essdev</url>
+			<url>https://repo.ess3.net/content/repositories/essdev</url>
 		</snapshotRepository>
 		<repository>
 			<id>essrel</id>
-			<url>http://repo.ess3.net/content/repositories/essrel</url>
+			<url>https://repo.ess3.net/content/repositories/essrel</url>
 		</repository>
 	</distributionManagement>
 

--- a/GL/atmosphere/Current/pom.xml
+++ b/GL/atmosphere/Current/pom.xml
@@ -398,16 +398,16 @@
     <repositories>
         <repository>
             <id>oss.sonatype.org</id>
-            <url>http://oss.sonatype.org/content/repositories/releases</url>
+            <url>https://oss.sonatype.org/content/repositories/releases</url>
         </repository>
         <repository>
             <id>oss.sonatype.org-snapshot</id>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
         <!-- <repository>
             <id>scala-tools.org</id>
             <name>Scala-Tools Maven2 Repository</name>
-            <url>http://scala-tools.org/repo-releases</url>
+            <url>https://scala-tools.org/repo-releases</url>
         </repository> -->
         <repository>
             <id>jboss</id>
@@ -416,11 +416,11 @@
         <repository>
             <id>codehaus</id>
             <name>repository.codehaus.org</name>
-            <url>http://repository.codehaus.org</url>
+            <url>https://repository.codehaus.org</url>
         </repository>
         <repository>
             <id>codehaus-snapshots</id>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <url>https://snapshots.repository.codehaus.org</url>
         </repository>
         <repository>
             <id>maven.java.net</id>

--- a/GL/cucumber-jvm/Current/pom.xml
+++ b/GL/cucumber-jvm/Current/pom.xml
@@ -485,13 +485,13 @@
     <repositories>
         <repository>
             <id>codehaus</id>
-            <url>http://repository.codehaus.org</url>
+            <url>https://repository.codehaus.org</url>
         </repository>
 
         <repository>
             <id>gosu-lang.org-releases</id>
             <name>Official Gosu website (releases)</name>
-            <url>http://gosu-lang.org/repositories/m2/releases</url>
+            <url>https://gosu-lang.org/repositories/m2/releases</url>
         </repository>
     </repositories>
 

--- a/GL/docx4j/atmosphere/Current/pom.xml
+++ b/GL/docx4j/atmosphere/Current/pom.xml
@@ -381,16 +381,16 @@
     <repositories>
         <repository>
             <id>oss.sonatype.org</id>
-            <url>http://oss.sonatype.org/content/repositories/releases</url>
+            <url>https://oss.sonatype.org/content/repositories/releases</url>
         </repository>
         <repository>
             <id>oss.sonatype.org-snapshot</id>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
         <!-- <repository>
             <id>scala-tools.org</id>
             <name>Scala-Tools Maven2 Repository</name>
-            <url>http://scala-tools.org/repo-releases</url>
+            <url>https://scala-tools.org/repo-releases</url>
         </repository> -->
         <repository>
             <id>jboss</id>
@@ -399,11 +399,11 @@
         <repository>
             <id>codehaus</id>
             <name>repository.codehaus.org</name>
-            <url>http://repository.codehaus.org</url>
+            <url>https://repository.codehaus.org</url>
         </repository>
         <repository>
             <id>codehaus-snapshots</id>
-            <url>http://snapshots.repository.codehaus.org</url>
+            <url>https://snapshots.repository.codehaus.org</url>
         </repository>
         <repository>
             <id>maven.java.net</id>

--- a/GL/elasticsearch/Current/pom.xml
+++ b/GL/elasticsearch/Current/pom.xml
@@ -46,7 +46,7 @@
     <repositories>
         <repository>
             <id>Codehaus Snapshots</id>
-            <url>http://repository.codehaus.org/</url>
+            <url>https://repository.codehaus.org/</url>
         </repository>
     </repositories>
 

--- a/GL/hadoop-common/Current/pom.xml
+++ b/GL/hadoop-common/Current/pom.xml
@@ -59,7 +59,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     </repository>
     <repository>
       <id>repository.jboss.org</id>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/GL/hbase/Current/pom.xml
+++ b/GL/hbase/Current/pom.xml
@@ -399,7 +399,7 @@
     <repository>
       <id>java.net</id>
       <name>Java.Net</name>
-      <url>http://download.java.net/maven/2/</url>
+      <url>https://download.java.net/maven/2/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -410,7 +410,7 @@
     <repository>
       <id>codehaus</id>
       <name>Codehaus Public</name>
-      <url>http://repository.codehaus.org/</url>
+      <url>https://repository.codehaus.org/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -420,7 +420,7 @@
     </repository>
     <repository>
       <id>repository.jboss.org</id>
-      <url>http://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+      <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
@@ -428,7 +428,7 @@
     <repository>
       <id>ghelmling.testing</id>
       <name>Gary Helmling test repo</name>
-      <url>http://people.apache.org/~garyh/mvn/</url>
+      <url>https://people.apache.org/~garyh/mvn/</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
@@ -441,7 +441,7 @@
     <pluginRepository>
       <id>ghelmling.testing</id>
       <name>Gary Helmling test repo</name>
-      <url>http://people.apache.org/~garyh/mvn/</url>
+      <url>https://people.apache.org/~garyh/mvn/</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/GL/openmrs-core/Current/pom.xml
+++ b/GL/openmrs-core/Current/pom.xml
@@ -969,7 +969,7 @@
 		<repository>
 			<id>openmrs-repo</id>
 			<name>OpenMRS Nexus Repository</name>
-			<url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
+			<url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
 		</repository>
 	</repositories>
 
@@ -977,7 +977,7 @@
 		<pluginRepository>
 			<id>openmrs-repo</id>
 			<name>OpenMRS Nexus Repository</name>
-			<url>http://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
+			<url>https://mavenrepo.openmrs.org/nexus/content/repositories/public</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -988,12 +988,12 @@
 		<repository>
 			<id>openmrs-repo-releases</id>
 			<name>OpenMRS Nexus Releases</name>
-			<url>http://mavenrepo.openmrs.org/nexus/content/repositories/releases</url>
+			<url>https://mavenrepo.openmrs.org/nexus/content/repositories/releases</url>
 		</repository>
 		<snapshotRepository>
 			<id>openmrs-repo-snapshots</id>
 			<name>OpenMRS Nexus Snapshots</name>
-			<url>http://mavenrepo.openmrs.org/nexus/content/repositories/snapshots</url>
+			<url>https://mavenrepo.openmrs.org/nexus/content/repositories/snapshots</url>
 		</snapshotRepository>
 	</distributionManagement>
 

--- a/GL/titan/Current/titan-berkeleyje/pom.xml
+++ b/GL/titan/Current/titan-berkeleyje/pom.xml
@@ -16,7 +16,7 @@
         <repository>
             <id>oracleReleases</id>
             <name>Oracle Released Java Packages</name>
-            <url>http://download.oracle.com/maven</url>
+            <url>https://download.oracle.com/maven</url>
             <layout>default</layout>
         </repository>
     </repositories>

--- a/GL/wildfly/Current/pom.xml
+++ b/GL/wildfly/Current/pom.xml
@@ -6492,7 +6492,7 @@
         <repository>
             <id>jboss-public-repository-group</id>
             <name>JBoss Public Repository Group</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
             <layout>default</layout>
             <releases>
                 <enabled>true</enabled>
@@ -6509,7 +6509,7 @@
         <pluginRepository>
             <id>jboss-public-repository-group</id>
             <name>JBoss Public Repository Group</name>
-            <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+            <url>https://repository.jboss.org/nexus/content/groups/public/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>

--- a/GL/wildfly/Current/testsuite/compat/pom.xml
+++ b/GL/wildfly/Current/testsuite/compat/pom.xml
@@ -319,7 +319,7 @@
     <repository>
       <id>jboss-public-repository-group</id>
       <name>JBoss Public Repository Group</name>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
+      <url>https://repository.jboss.org/nexus/content/groups/public/</url>
       <layout>default</layout>
       <releases>
         <enabled>true</enabled>

--- a/GL/wildfly/Current/testsuite/pom.xml
+++ b/GL/wildfly/Current/testsuite/pom.xml
@@ -701,7 +701,7 @@
             <repositories>
                 <repository>
                     <id>JBoss QA repository</id>
-                    <url>http://nexus.qa.jboss.com:8081/nexus/content/repositories/thirdparty</url>
+                    <url>https://nexus.qa.jboss.com:8081/nexus/content/repositories/thirdparty</url>
                 </repository>
             </repositories>
             <build>

--- a/Java/dropwizard/dropwizard-example/pom.xml
+++ b/Java/dropwizard/dropwizard-example/pom.xml
@@ -29,7 +29,7 @@
         <repository>
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </repository>
     </repositories>
 

--- a/Java/dropwizard/pom.xml
+++ b/Java/dropwizard/pom.xml
@@ -216,7 +216,7 @@
         <repository>
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
             <releases>
                 <enabled>false</enabled>
             </releases>
@@ -230,7 +230,7 @@
         <snapshotRepository>
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>sonatype-nexus-staging</id>

--- a/Java/druid/extensions-contrib/ambari-metrics-emitter/pom.xml
+++ b/Java/druid/extensions-contrib/ambari-metrics-emitter/pom.xml
@@ -85,7 +85,7 @@
     <repository>
       <id>hortonworks</id>
       <name>hortonworks</name>
-      <url>http://repo.hortonworks.com/content/repositories/releases</url>
+      <url>https://repo.hortonworks.com/content/repositories/releases</url>
     </repository>
   </repositories>
 </project>

--- a/Java/druid/extensions-core/avro-extensions/pom.xml
+++ b/Java/druid/extensions-core/avro-extensions/pom.xml
@@ -43,7 +43,7 @@
   <repositories>
     <repository>
       <id>confluent</id>
-      <url>http://packages.confluent.io/maven/</url>
+      <url>https://packages.confluent.io/maven/</url>
     </repository>
   </repositories>
 

--- a/Java/java-design-patterns/naked-objects/pom.xml
+++ b/Java/java-design-patterns/naked-objects/pom.xml
@@ -47,7 +47,7 @@
 		</repository>
 		<repository>
 			<id>Cloudbees snapshots</id>
-			<url>http://repository-estatio.forge.cloudbees.com/snapshot/</url>
+			<url>https://repository-estatio.forge.cloudbees.com/snapshot/</url>
 			<snapshots>
 			</snapshots>
 			<releases>

--- a/Java/kotlin/libraries/examples/annotation-processor-example/pom.xml
+++ b/Java/kotlin/libraries/examples/annotation-processor-example/pom.xml
@@ -83,7 +83,7 @@
     <repositories>
         <repository>
             <id>jetbrains-utils</id>
-            <url>http://repository.jetbrains.com/utils</url>
+            <url>https://repository.jetbrains.com/utils</url>
         </repository>
     </repositories>
 </project>

--- a/Java/kotlin/libraries/examples/browser-example/pom.xml
+++ b/Java/kotlin/libraries/examples/browser-example/pom.xml
@@ -162,7 +162,7 @@
                 <repository>
                   <id>snapshots.fusesource.org</id>
                   <name>FuseSource Snapshots Repository</name>
-                  <url>http://repo.fusesource.com/nexus/content/repositories/snapshots</url>
+                  <url>https://repo.fusesource.com/nexus/content/repositories/snapshots</url>
                   <snapshots>
                     <enabled>false</enabled>
                   </snapshots>

--- a/Java/kotlin/libraries/examples/kotlin-gradle-subplugin-example/pom.xml
+++ b/Java/kotlin/libraries/examples/kotlin-gradle-subplugin-example/pom.xml
@@ -96,7 +96,7 @@
     <repositories>
         <repository>
             <id>jetbrains-utils</id>
-            <url>http://repository.jetbrains.com/utils</url>
+            <url>https://repository.jetbrains.com/utils</url>
         </repository>
     </repositories>
 </project>

--- a/Java/kotlin/libraries/tools/kotlin-allopen/pom.xml
+++ b/Java/kotlin/libraries/tools/kotlin-allopen/pom.xml
@@ -28,7 +28,7 @@
     <repositories>
         <repository>
             <id>jetbrains-utils</id>
-            <url>http://repository.jetbrains.com/utils</url>
+            <url>https://repository.jetbrains.com/utils</url>
         </repository>
     </repositories>
 

--- a/Java/kotlin/libraries/tools/kotlin-android-extensions/pom.xml
+++ b/Java/kotlin/libraries/tools/kotlin-android-extensions/pom.xml
@@ -121,7 +121,7 @@
     <repositories>
         <repository>
             <id>jetbrains-utils</id>
-            <url>http://repository.jetbrains.com/utils</url>
+            <url>https://repository.jetbrains.com/utils</url>
         </repository>
     </repositories>
 </project>

--- a/Java/kotlin/libraries/tools/kotlin-annotation-processing/pom.xml
+++ b/Java/kotlin/libraries/tools/kotlin-annotation-processing/pom.xml
@@ -28,7 +28,7 @@
     <repositories>
         <repository>
             <id>jetbrains-utils</id>
-            <url>http://repository.jetbrains.com/utils</url>
+            <url>https://repository.jetbrains.com/utils</url>
         </repository>
     </repositories>
 

--- a/Java/kotlin/libraries/tools/kotlin-gradle-plugin-api/pom.xml
+++ b/Java/kotlin/libraries/tools/kotlin-gradle-plugin-api/pom.xml
@@ -24,7 +24,7 @@
     <repositories>
         <repository>
             <id>jetbrains-utils</id>
-            <url>http://repository.jetbrains.com/utils</url>
+            <url>https://repository.jetbrains.com/utils</url>
         </repository>
     </repositories>
 

--- a/Java/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/pom.xml
+++ b/Java/kotlin/libraries/tools/kotlin-gradle-plugin-integration-tests/pom.xml
@@ -161,12 +161,12 @@
     <repositories>
         <repository>
             <id>jetbrains-utils</id>
-            <url>http://repository.jetbrains.com/utils</url>
+            <url>https://repository.jetbrains.com/utils</url>
         </repository>
         <repository>
             <id>central</id>
             <name>bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
 </project>

--- a/Java/kotlin/libraries/tools/kotlin-gradle-plugin/gradle_api_jar/pom.xml
+++ b/Java/kotlin/libraries/tools/kotlin-gradle-plugin/gradle_api_jar/pom.xml
@@ -45,7 +45,7 @@
   <distributionManagement>
     <repository>
       <id>utils</id>
-      <url>http://repository.jetbrains.com/utils</url>
+      <url>https://repository.jetbrains.com/utils</url>
     </repository>
   </distributionManagement>
 

--- a/Java/kotlin/libraries/tools/kotlin-gradle-plugin/pom.xml
+++ b/Java/kotlin/libraries/tools/kotlin-gradle-plugin/pom.xml
@@ -185,12 +185,12 @@
     <repositories>
         <repository>
             <id>jetbrains-utils</id>
-            <url>http://repository.jetbrains.com/utils</url>
+            <url>https://repository.jetbrains.com/utils</url>
         </repository>
         <repository>
             <id>central</id>
             <name>bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
 

--- a/Java/kotlin/libraries/tools/kotlin-maven-allopen/pom.xml
+++ b/Java/kotlin/libraries/tools/kotlin-maven-allopen/pom.xml
@@ -28,7 +28,7 @@
     <repositories>
         <repository>
             <id>jetbrains-utils</id>
-            <url>http://repository.jetbrains.com/utils</url>
+            <url>https://repository.jetbrains.com/utils</url>
         </repository>
     </repositories>
 

--- a/Java/kotlin/libraries/tools/kotlin-maven-noarg/pom.xml
+++ b/Java/kotlin/libraries/tools/kotlin-maven-noarg/pom.xml
@@ -28,7 +28,7 @@
     <repositories>
         <repository>
             <id>jetbrains-utils</id>
-            <url>http://repository.jetbrains.com/utils</url>
+            <url>https://repository.jetbrains.com/utils</url>
         </repository>
     </repositories>
 

--- a/Java/kotlin/libraries/tools/kotlin-noarg/pom.xml
+++ b/Java/kotlin/libraries/tools/kotlin-noarg/pom.xml
@@ -28,7 +28,7 @@
     <repositories>
         <repository>
             <id>jetbrains-utils</id>
-            <url>http://repository.jetbrains.com/utils</url>
+            <url>https://repository.jetbrains.com/utils</url>
         </repository>
     </repositories>
 

--- a/Java/kotlin/libraries/tools/kotlin-script-util/pom.xml
+++ b/Java/kotlin/libraries/tools/kotlin-script-util/pom.xml
@@ -24,7 +24,7 @@
     <repositories>
         <repository>
             <id>jetbrains-utils</id>
-            <url>http://repository.jetbrains.com/utils</url>
+            <url>https://repository.jetbrains.com/utils</url>
         </repository>
     </repositories>
 

--- a/Java/kotlin/libraries/tools/kotlin-stdlib-gen/pom.xml
+++ b/Java/kotlin/libraries/tools/kotlin-stdlib-gen/pom.xml
@@ -26,7 +26,7 @@
             <snapshots><enabled>false</enabled></snapshots>
             <id>bintray-kotlin-kotlin-eap-1.1</id>
             <name>bintray</name>
-            <url>http://dl.bintray.com/kotlin/kotlin-eap-1.1</url>
+            <url>https://dl.bintray.com/kotlin/kotlin-eap-1.1</url>
         </repository>
     </repositories>
     <pluginRepositories>
@@ -34,7 +34,7 @@
             <snapshots><enabled>false</enabled></snapshots>
             <id>bintray-kotlin-kotlin-eap-1.1</id>
             <name>bintray</name>
-            <url>http://dl.bintray.com/kotlin/kotlin-eap-1.1</url>
+            <url>https://dl.bintray.com/kotlin/kotlin-eap-1.1</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/Java/metrics/pom.xml
+++ b/Java/metrics/pom.xml
@@ -97,12 +97,12 @@
         <snapshotRepository>
             <id>sonatype-nexus-snapshots</id>
             <name>Sonatype Nexus Snapshots</name>
-            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
             <id>sonatype-nexus-staging</id>
             <name>Nexus Release Repository</name>
-            <url>http://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 

--- a/Java/neo4j/community/server/pom.xml
+++ b/Java/neo4j/community/server/pom.xml
@@ -537,7 +537,7 @@
         <repository>
           <id>neo4j-dev</id>
           <name>Neo4j Developer Repository</name>
-          <url>http://m2.neo4j.org/content/groups/everything/</url>
+          <url>https://m2.neo4j.org/content/groups/everything/</url>
         </repository>
       </repositories>
     </profile>
@@ -546,12 +546,12 @@
   <repositories>
     <repository>
       <id>java.net</id>
-      <url>http://download.java.net/maven/2/</url>
+      <url>https://download.java.net/maven/2/</url>
     </repository>
     <repository>
       <id>neo4j-release-repository</id>
       <name>Neo4j Maven 2 release repository</name>
-      <url>http://m2.neo4j.org/content/repositories/releases</url>
+      <url>https://m2.neo4j.org/content/repositories/releases</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -562,7 +562,7 @@
     <repository>
       <id>neo4j-snapshot-repository</id>
       <name>Neo4j Maven 2 snapshot repository</name>
-      <url>http://m2.neo4j.org/content/repositories/snapshots</url>
+      <url>https://m2.neo4j.org/content/repositories/snapshots</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
@@ -575,7 +575,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>jsdoctk2</id>
-      <url>http://jsdoctk-plugin.googlecode.com/svn/repo</url>
+      <url>https://jsdoctk-plugin.googlecode.com/svn/repo</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/Java/neo4j/enterprise/cypher/compatibility-spec-suite/pom.xml
+++ b/Java/neo4j/enterprise/cypher/compatibility-spec-suite/pom.xml
@@ -54,7 +54,7 @@
     <repository>
       <id>neo4j-releases-repository</id>
       <name>Neo4j Maven 2 releases repository</name>
-      <url>http://m2.neo4j.org/content/repositories/releases/</url>
+      <url>https://m2.neo4j.org/content/repositories/releases/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/Java/neo4j/enterprise/cypher/spec-suite-tools/pom.xml
+++ b/Java/neo4j/enterprise/cypher/spec-suite-tools/pom.xml
@@ -55,7 +55,7 @@
     <repository>
       <id>neo4j-releases-repository</id>
       <name>Neo4j Maven 2 releases repository</name>
-      <url>http://m2.neo4j.org/content/repositories/releases/</url>
+      <url>https://m2.neo4j.org/content/repositories/releases/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/Java/neo4j/enterprise/server-enterprise/pom.xml
+++ b/Java/neo4j/enterprise/server-enterprise/pom.xml
@@ -295,7 +295,7 @@
         <repository>
           <id>neo4j-dev</id>
           <name>Neo4j Developer Repository</name>
-          <url>http://m2.neo4j.org/content/groups/everything/</url>
+          <url>https://m2.neo4j.org/content/groups/everything/</url>
         </repository>
       </repositories>
     </profile>
@@ -305,7 +305,7 @@
     <repository>
       <id>neo4j-release-repository</id>
       <name>Neo4j Maven 2 release repository</name>
-      <url>http://m2.neo4j.org/content/repositories/releases</url>
+      <url>https://m2.neo4j.org/content/repositories/releases</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -316,7 +316,7 @@
     <repository>
       <id>neo4j-snapshot-repository</id>
       <name>Neo4j Maven 2 snapshot repository</name>
-      <url>http://m2.neo4j.org/content/repositories/snapshots</url>
+      <url>https://m2.neo4j.org/content/repositories/snapshots</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/Java/neo4j/packaging/standalone/pom.xml
+++ b/Java/neo4j/packaging/standalone/pom.xml
@@ -279,7 +279,7 @@
     <repository>
       <id>neo4j-release-repository</id>
       <name>Neo4j Maven 2 release repository</name>
-      <url>http://m2.neo4j.org/content/repositories/releases</url>
+      <url>https://m2.neo4j.org/content/repositories/releases</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -290,7 +290,7 @@
     <repository>
       <id>neo4j-snapshot-repository</id>
       <name>Neo4j Maven 2 snapshot repository</name>
-      <url>http://m2.neo4j.org/content/repositories/snapshots</url>
+      <url>https://m2.neo4j.org/content/repositories/snapshots</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/Java/spring-boot/spring-boot-dependencies/pom.xml
+++ b/Java/spring-boot/spring-boot-dependencies/pom.xml
@@ -2626,7 +2626,7 @@
 				<repository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/milestone</url>
+					<url>https://repo.spring.io/milestone</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -2634,7 +2634,7 @@
 				<repository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/snapshot</url>
+					<url>https://repo.spring.io/snapshot</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>

--- a/Java/spring-boot/spring-boot-integration-tests/spring-boot-gradle-tests/pom.xml
+++ b/Java/spring-boot/spring-boot-integration-tests/spring-boot-gradle-tests/pom.xml
@@ -75,7 +75,7 @@
 	<repositories>
 		<repository>
 			<id>gradle</id>
-			<url>http://repo.gradle.org/gradle/libs-releases-local</url>
+			<url>https://repo.gradle.org/gradle/libs-releases-local</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>

--- a/Java/spring-boot/spring-boot-parent/pom.xml
+++ b/Java/spring-boot/spring-boot-parent/pom.xml
@@ -652,7 +652,7 @@
 			<repositories>
 				<repository>
 					<id>spring-ext</id>
-					<url>http://repo.spring.io/ext-release-local/</url>
+					<url>https://repo.spring.io/ext-release-local/</url>
 					<releases>
 						<enabled>true</enabled>
 					</releases>
@@ -663,7 +663,7 @@
 				<repository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/milestone</url>
+					<url>https://repo.spring.io/milestone</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -671,7 +671,7 @@
 				<repository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/snapshot</url>
+					<url>https://repo.spring.io/snapshot</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
@@ -689,7 +689,7 @@
 				<pluginRepository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/milestone</url>
+					<url>https://repo.spring.io/milestone</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -697,7 +697,7 @@
 				<pluginRepository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/snapshot</url>
+					<url>https://repo.spring.io/snapshot</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
@@ -717,7 +717,7 @@
 			<repositories>
 				<repository>
 					<id>spring-ext</id>
-					<url>http://repo.spring.io/ext-release-local/</url>
+					<url>https://repo.spring.io/ext-release-local/</url>
 					<releases>
 						<enabled>true</enabled>
 					</releases>
@@ -728,7 +728,7 @@
 				<repository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/milestone</url>
+					<url>https://repo.spring.io/milestone</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -736,7 +736,7 @@
 				<repository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/snapshot</url>
+					<url>https://repo.spring.io/snapshot</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
@@ -754,7 +754,7 @@
 				<pluginRepository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/milestone</url>
+					<url>https://repo.spring.io/milestone</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -762,7 +762,7 @@
 				<pluginRepository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/snapshot</url>
+					<url>https://repo.spring.io/snapshot</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
@@ -801,7 +801,7 @@
 			<repositories>
 				<repository>
 					<id>spring-ext</id>
-					<url>http://repo.spring.io/ext-release-local/</url>
+					<url>https://repo.spring.io/ext-release-local/</url>
 					<releases>
 						<enabled>true</enabled>
 					</releases>
@@ -812,7 +812,7 @@
 				<repository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/milestone</url>
+					<url>https://repo.spring.io/milestone</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -820,7 +820,7 @@
 				<repository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/snapshot</url>
+					<url>https://repo.spring.io/snapshot</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
@@ -838,7 +838,7 @@
 				<pluginRepository>
 					<id>spring-milestones</id>
 					<name>Spring Milestones</name>
-					<url>http://repo.spring.io/milestone</url>
+					<url>https://repo.spring.io/milestone</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>
@@ -846,7 +846,7 @@
 				<pluginRepository>
 					<id>spring-snapshots</id>
 					<name>Spring Snapshots</name>
-					<url>http://repo.spring.io/snapshot</url>
+					<url>https://repo.spring.io/snapshot</url>
 					<snapshots>
 						<enabled>true</enabled>
 					</snapshots>
@@ -858,7 +858,7 @@
 			<repositories>
 				<repository>
 					<id>spring-ext</id>
-					<url>http://repo.spring.io/ext-release-local/</url>
+					<url>https://repo.spring.io/ext-release-local/</url>
 					<releases>
 						<enabled>true</enabled>
 					</releases>
@@ -892,7 +892,7 @@
 				<pluginRepository>
 					<id>objectstyle</id>
 					<name>ObjectStyle.org Repository</name>
-					<url>http://objectstyle.org/maven2/</url>
+					<url>https://objectstyle.org/maven2/</url>
 					<snapshots>
 						<enabled>false</enabled>
 					</snapshots>

--- a/Java/spring-boot/spring-boot-samples/pom.xml
+++ b/Java/spring-boot/spring-boot-samples/pom.xml
@@ -228,7 +228,7 @@
 		<repository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -236,7 +236,7 @@
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/milestone</url>
+			<url>https://repo.spring.io/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -246,7 +246,7 @@
 		<pluginRepository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
-			<url>http://repo.spring.io/snapshot</url>
+			<url>https://repo.spring.io/snapshot</url>
 			<snapshots>
 				<enabled>true</enabled>
 			</snapshots>
@@ -254,7 +254,7 @@
 		<pluginRepository>
 			<id>spring-milestones</id>
 			<name>Spring Milestones</name>
-			<url>http://repo.spring.io/milestone</url>
+			<url>https://repo.spring.io/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -262,7 +262,7 @@
 		<pluginRepository>
 			<id>spring-releases</id>
 			<name>Spring Releases</name>
-			<url>http://repo.spring.io/release</url>
+			<url>https://repo.spring.io/release</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/Java/spring-boot/spring-boot-samples/spring-boot-sample-custom-layout/pom.xml
+++ b/Java/spring-boot/spring-boot-samples/spring-boot-sample-custom-layout/pom.xml
@@ -99,7 +99,7 @@
 	<repositories>
 		<repository>
 			<id>gradle</id>
-			<url>http://repo.gradle.org/gradle/libs-releases-local</url>
+			<url>https://repo.gradle.org/gradle/libs-releases-local</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>

--- a/Java/spring-boot/spring-boot-tools/spring-boot-gradle-plugin/pom.xml
+++ b/Java/spring-boot/spring-boot-tools/spring-boot-gradle-plugin/pom.xml
@@ -67,7 +67,7 @@
 	<repositories>
 		<repository>
 			<id>gradle</id>
-			<url>http://repo.gradle.org/gradle/libs-releases-local</url>
+			<url>https://repo.gradle.org/gradle/libs-releases-local</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>

--- a/Java/zipkin/pom.xml
+++ b/Java/zipkin/pom.xml
@@ -129,7 +129,7 @@
     </repository>
     <snapshotRepository>
       <id>jfrog-snapshots</id>
-      <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+      <url>https://oss.jfrog.org/artifactory/oss-snapshot-local</url>
     </snapshotRepository>
   </distributionManagement>
 

--- a/gora-master/gora-couchdb/pom.xml
+++ b/gora-master/gora-couchdb/pom.xml
@@ -120,7 +120,7 @@
   <repositories>
     <repository>
       <id>clojars.org</id>
-      <url>http://clojars.org/repo</url>
+      <url>https://clojars.org/repo</url>
     </repository>
   </repositories>
 

--- a/gora-master/gora-solr-5/pom.xml
+++ b/gora-master/gora-solr-5/pom.xml
@@ -88,7 +88,7 @@
     <repository>
       <id>maven-restlet</id>
       <name>Public online Restlet repository</name>
-      <url>http://maven.restlet.org</url>
+      <url>https://maven.restlet.org</url>
     </repository>
   </repositories>
 

--- a/gora-master/gora-solr/pom.xml
+++ b/gora-master/gora-solr/pom.xml
@@ -87,7 +87,7 @@
     <repository>
       <id>maven-restlet</id>
       <name>Public online Restlet repository</name>
-      <url>http://maven.restlet.org</url>
+      <url>https://maven.restlet.org</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
[![mitm_build](https://user-images.githubusercontent.com/1323708/59226671-90645200-8ba1-11e9-8ab3-39292bef99e9.jpeg)](https://medium.com/@jonathan.leitschuh/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb?source=friends_link&sk=3c99970c55a899ad9ef41f126efcde0e)

- [Want to take over the Java ecosystem? All you need is a MITM!](https://medium.com/@jonathan.leitschuh/want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-1fc329d898fb?source=friends_link&sk=3c99970c55a899ad9ef41f126efcde0e)
- [Update: Want to take over the Java ecosystem? All you need is a MITM!](https://medium.com/bugbountywriteup/update-want-to-take-over-the-java-ecosystem-all-you-need-is-a-mitm-d069d253fe23?source=friends_link&sk=8c8e52a7d57b98d0b7e541665688b454)

---

This is a security fix for a  vulnerability in your [Apache Maven](https://maven.apache.org/) `pom.xml` file(s).

The build files indicate that this project is resolving dependencies over HTTP instead of HTTPS.
This leaves your build vulnerable to allowing a [Man in the Middle](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) (MITM) attackers to execute arbitrary code on your or your computer or CI/CD system.

This vulnerability has a CVSS v3.0 Base Score of [8.1/10](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H).

[POC code](https://max.computer/blog/how-to-take-over-the-computer-of-any-java-or-clojure-or-scala-developer/) has existed since 2014 to maliciously compromise a JAR file in-flight.
MITM attacks against HTTP are [increasingly common](https://security.stackexchange.com/a/12050), for example [Comcast is known to have done it to their own users](https://thenextweb.com/insights/2017/12/11/comcast-continues-to-inject-its-own-code-into-websites-you-visit/#).

This contribution is a part of a submission to the [GitHub Security Lab](https://securitylab.github.com/) Bug Bounty program.

## Detecting this and Future Vulnerabilities

This vulnerability was automatically detected by [LGTM.com](https://lgtm.com) using this [CodeQL Query](https://lgtm.com/rules/1511115648721/).

As of September 2019 LGTM.com and Semmle are [officially a part of GitHub](https://github.blog/2019-09-18-github-welcomes-semmle/).

You can automatically detect future vulnerabilities like this by enabling the free (for open-source) [LGTM App](https://github.com/marketplace/lgtm).

I'm not an employee of GitHub nor of Semmle, I'm simply a user of [LGTM.com](https://lgtm.com) and an open-source security researcher.

## Source

Yes, this contribution was automatically generated, however, the code to generate this PR was lovingly hand crafted to bring this security fix to your repository.

The source code that generated and submitted this PR can be found here:
[JLLeitschuh/bulk-security-pr-generator](https://github.com/JLLeitschuh/bulk-security-pr-generator)

## Opting-Out

If you'd like to opt-out of future automated security vulnerability fixes like this, please consider adding a file called
`.github/GH-ROBOTS.txt` to your repository with the line:

```
User-agent: JLLeitschuh/bulk-security-pr-generator
Disallow: *
```

This bot will respect the [ROBOTS.txt](https://moz.com/learn/seo/robotstxt) format for future contributions.

Alternatively, if this project is no longer actively maintained, consider [archiving](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-archiving-repositories) the repository.

## CLA Requirements

_This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions._

It is unlikely that I'll be able to directly sign CLAs. However, all contributed commits are already automatically signed-off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin 
> (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
>
> \- [Git Commit Signoff documentation](https://developercertificate.org/)

If signing your organization's CLA is a strict-requirement for merging this contribution, please feel free to close this PR.

## Tracking

All PR's generated as part of this fix are tracked here: 
https://github.com/JLLeitschuh/bulk-security-pr-generator/issues/2